### PR TITLE
DOC add information about re-building cython extensions

### DIFF
--- a/2.building.md
+++ b/2.building.md
@@ -6,7 +6,7 @@ To build scikit-learn from source, we need to make sure that we have scikit-lear
 ```
 $ conda install numpy scipy cython  # should be already installed
 $ cd scikit-learn/
-$ pip install --verbose --no-build-isolation -e .
+$ pip install --verbose --no-use-pep517 --no-build-isolation -e .
 $ cd ..
 $ pip show scikit-learn
 ```

--- a/4.test.md
+++ b/4.test.md
@@ -162,3 +162,9 @@ is used to test the docstring compliancy:
 ```
 $ pytest --doctest-modules sklearn/ensemble/_forest.py -k RandomForestClassifier
 ```
+
+# Debugging
+
+If you see an `ImportError` when running `pytest` you might need to re-build the Cython
+extensions. You can do this with the command `pip install -v --no-use-pep517 --no-build-isolation -e .`.
+On Unix-like systems you can instead also type `make in` from the top-level folder of the project.


### PR DESCRIPTION
As explained [here](https://github.com/scikit-learn/scikit-learn/issues/25985) new contributors often aren't aware that they need to re-build the cython extensions on a regular basis. In my case I generally realise that I need to re-build the extensions when I run `pytest` and get an import error. I therefore added a section called "Debugging" to the file `4.test.md` to make it easier for new contributors to understand that seeing an import error when running `pytest` can be due to out of date extensions. 

edit: I also included the `--no-use-pep517` flag in `2.building.md`